### PR TITLE
ci: use PAT for commitizen release prs to ensure CI runs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,8 @@ jobs:
       - name: release
         id: release
         uses: google-github-actions/release-please-action@v3.7.13
+        env:
+          GITHUB_TOKEN: ${{ secrets.RELEASE_ACTION_TOKEN }}
         with:
           # https://github.com/google-github-actions/release-please-action#configuration
           release-type: python


### PR DESCRIPTION
### Description

ci: use PAT for commitizen release prs to ensure CI runs

![image](https://github.com/apoclyps/python-package-publish/assets/1443700/8a1cf3bb-db79-4e27-b424-1c07131d9706)

![image](https://github.com/apoclyps/python-package-publish/assets/1443700/3adb1b4d-27e2-4dac-810c-44dbbd3da625)

![image](https://github.com/apoclyps/python-package-publish/assets/1443700/3a6d8b8d-dce5-498a-8be6-e5f2d8b78259)

## Changes

This PR implements the following changes:

1. ci: use PAT for commitizen release prs to ensure CI runs
